### PR TITLE
unsubscribe from SearchParamsService

### DIFF
--- a/src/app/search-results/search-results.component.spec.ts
+++ b/src/app/search-results/search-results.component.spec.ts
@@ -3,33 +3,40 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { MaterialModule } from '../material-module';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 
 import { SearchResultsComponent } from './search-results.component';
 import { KuiActionModule } from '@knora/action';
 import { ReadDateValueComponent } from '../properties/read-date-value/read-date-value.component';
-import { KuiCoreConfig } from '@knora/core';
+import { ExtendedSearchParams, KuiCoreConfig, SearchParamsService } from '@knora/core';
 
 import { MathJaxDirective } from '../directives/mathjax.directive';
+import { MatExpansionModule, MatIconModule } from '@angular/material';
 
 
 describe('SearchResultsComponent', () => {
     let component: SearchResultsComponent;
     let fixture: ComponentFixture<SearchResultsComponent>;
-    const mode = 'fulltext';
-    const q = 'haus';
+    const mode = 'extended';
+    const q = 'test';
+
+    let mockSearchParamService;
 
     beforeEach(async(() => {
+
+        mockSearchParamService = new MockSearchParamsService();
+
         TestBed.configureTestingModule({
             imports: [
                 KuiActionModule,
                 RouterTestingModule,
-                MaterialModule,
-                InfiniteScrollModule,
                 HttpClientModule,
-                HttpClientTestingModule],
+                HttpClientTestingModule,
+                MatIconModule,
+                MatExpansionModule
+            ],
             declarations: [
                 SearchResultsComponent,
                 MathJaxDirective,
@@ -40,7 +47,8 @@ describe('SearchResultsComponent', () => {
                     provide: ActivatedRoute,
                     useValue: { params: of({ mode, q }) }
                 },
-                { provide: 'config', useValue: KuiCoreConfig }
+                { provide: 'config', useValue: KuiCoreConfig },
+                { provide: SearchParamsService, useValue: mockSearchParamService}
             ]
         })
             .compileComponents();
@@ -55,4 +63,27 @@ describe('SearchResultsComponent', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('should have subscribed to SearchParamService', () => {
+        expect(component.extendedSearchParamsSubscription.closed).toBeFalsy();
+    });
+
+    it('should have unsubscribed from SearchParamService after component destruction', () => {
+        component.ngOnDestroy();
+
+        fixture.detectChanges();
+
+        expect(component.extendedSearchParamsSubscription.closed).toBeTruthy();
+    });
 });
+
+class MockSearchParamsService {
+
+    public currentSearchParams: Observable<any>;
+
+    constructor() {
+        this.currentSearchParams = new BehaviorSubject<any>(1).asObservable();
+    }
+
+
+}

--- a/src/app/search-results/search-results.component.ts
+++ b/src/app/search-results/search-results.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
@@ -16,6 +16,7 @@ import {
 } from '@knora/core';
 import { BeolService } from '../services/beol.service';
 import { environment } from '../../environments/environment';
+import { Subscription } from 'rxjs';
 
 declare let require: any;
 const jsonld = require('jsonld');
@@ -25,7 +26,7 @@ const jsonld = require('jsonld');
     templateUrl: './search-results.component.html',
     styleUrls: ['./search-results.component.scss']
 })
-export class SearchResultsComponent implements OnInit {
+export class SearchResultsComponent implements OnInit, OnDestroy {
 
     isLoading = true;
 
@@ -48,6 +49,8 @@ export class SearchResultsComponent implements OnInit {
 
     searchQuery: string;
     searchMode: string;
+
+    extendedSearchParamsSubscription: Subscription;
 
     constructor(
         private _route: ActivatedRoute,
@@ -74,6 +77,15 @@ export class SearchResultsComponent implements OnInit {
             this.rerender = false;
         });
 
+    }
+
+    ngOnDestroy() {
+        // unsubscribe from extendedSearchParamsSubscription
+        // otherwise old queries are still active
+        if (this.searchMode === 'extended' && this.extendedSearchParamsSubscription !== undefined) {
+            console.log(this.searchMode)
+            this.extendedSearchParamsSubscription.unsubscribe();
+        }
     }
 
     /**
@@ -118,7 +130,7 @@ export class SearchResultsComponent implements OnInit {
                     );
             }
             // perform the extended search
-            this._searchParamsService.currentSearchParams
+            this.extendedSearchParamsSubscription = this._searchParamsService.currentSearchParams
                 .subscribe((extendedSearchParams: ExtendedSearchParams) => {
 
                     if (this.offset === 0) {

--- a/src/app/search-results/search-results.component.ts
+++ b/src/app/search-results/search-results.component.ts
@@ -92,6 +92,9 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
      */
     getResult() {
 
+        this.result = [];
+        this.resetStep();
+
         // FULLTEXT SEARCH
         if (this.searchMode === 'fulltext') {
             // perform count query

--- a/src/app/search-results/search-results.component.ts
+++ b/src/app/search-results/search-results.component.ts
@@ -83,7 +83,6 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
         // unsubscribe from extendedSearchParamsSubscription
         // otherwise old queries are still active
         if (this.searchMode === 'extended' && this.extendedSearchParamsSubscription !== undefined) {
-            console.log(this.searchMode)
             this.extendedSearchParamsSubscription.unsubscribe();
         }
     }


### PR DESCRIPTION
When doing an extended search, a subscription to `SearchParamsService` is acquired in `SearchResultsComponent`.

When `SearchResultsComponent` is destroyed, the subscription has to be cancelled. Otherwise the old subscriptions are still active, causing unnecessary calls to the Knora API.