### PR TITLE
Handle parameters in abstract class

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -31,33 +31,27 @@ const appRoutes: Routes = [
     },
     {
         path: 'resource/:id',
-        component: ResourceComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: ResourceComponent
     },
     {
         path: 'person/:id',
-        component: PersonComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: PersonComponent
     },
     {
         path: 'figure/:id',
-        component: FigureComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: FigureComponent
     },
     {
         path: 'biblio/:id',
-        component: BiblioItemsComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: BiblioItemsComponent
     },
     {
         path: 'letter/:id',
-        component: LetterComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: LetterComponent
     },
     {
         path: 'endnote/:id',
-        component: EndnoteComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: EndnoteComponent
     },
     {
         path: 'search',

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -22,8 +22,7 @@ const appRoutes: Routes = [
     },
     {
         path: 'introduction/:project/:id',
-        component: IntroductionComponent,
-        runGuardsAndResolvers: 'paramsChange'
+        component: IntroductionComponent
     },
     {
         path: 'correspondence/:project',

--- a/src/app/introduction/introduction.component.spec.ts
+++ b/src/app/introduction/introduction.component.spec.ts
@@ -61,7 +61,15 @@ describe('IntroductionComponent', () => {
             providers: [
                 {
                     provide: ActivatedRoute,
-                    useValue: {params: of({project, id})}
+                    useValue: { paramMap: of({
+                                get: (param) => {
+                                    if (param === 'project') {
+                                        return project;
+                                    } else {
+                                        return id;
+                                    }
+                                }}
+                        )}
                 },
                 { provide: BeolService, useValue: spyBeolService },
                 { provide: SearchService, useValue: spySearchService },

--- a/src/app/introduction/introduction.component.ts
+++ b/src/app/introduction/introduction.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, ParamMap, Params, Router } from '@angular/router';
 import {
     ApiServiceError,
     ApiServiceResult,
@@ -19,6 +19,7 @@ import { BeolService } from '../services/beol.service';
 import { JsonObject, JsonProperty } from 'json2typescript';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
+import { Subscription } from 'rxjs';
 
 declare let require: any;
 const jsonld = require('jsonld');
@@ -42,7 +43,7 @@ export interface Introduction {
     templateUrl: './introduction.component.html',
     styleUrls: ['./introduction.component.scss']
 })
-export class IntroductionComponent implements OnInit {
+export class IntroductionComponent implements OnInit, OnDestroy {
 
     id: string;
     iri: string;
@@ -62,6 +63,8 @@ export class IntroductionComponent implements OnInit {
     curChildIndex: number;
 
     isLoading = true;
+
+    paramsSubscription: Subscription;
 
     propIris: any = {
         'title': environment.externalApiURL + '/ontology/0801/beol/v2#sectionHasTitle',
@@ -84,13 +87,19 @@ export class IntroductionComponent implements OnInit {
         const intro  = require('../../assets/data/introduction.json');
         this.list = <Introduction[]> intro.introductions;
 
-        this._route.params.subscribe((params: Params) => {
-            this.project = params['project'];
-            this.id = params['id'];
+        this.paramsSubscription = this._route.paramMap.subscribe((params: ParamMap) => {
+            this.project = params.get('project');
+            this.id = params.get('id');
 
             this.searchForBook(this.id);
         });
 
+    }
+
+    ngOnDestroy() {
+        if (this.paramsSubscription !== undefined) {
+            this.paramsSubscription.unsubscribe();
+        }
     }
 
     searchForBook(id: string): void {

--- a/src/app/resource/beol-resource.ts
+++ b/src/app/resource/beol-resource.ts
@@ -157,10 +157,9 @@ export abstract class BeolResource implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        if (this.navigationSubscription) {
+        if (this.navigationSubscription !== undefined) {
             this.navigationSubscription.unsubscribe();
         }
-
     }
 
     /**

--- a/src/app/resource/beol-resource.ts
+++ b/src/app/resource/beol-resource.ts
@@ -20,6 +20,8 @@ import { RequestStillImageRepresentations } from '@knora/viewer';
 import { Subscription } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { BeolService } from '../services/beol.service';
+import { ActivatedRoute, ParamMap } from '@angular/router';
+import { OnDestroy, OnInit } from '@angular/core';
 
 declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
 let jsonld = require('jsonld');
@@ -32,7 +34,7 @@ export interface PropertyValues {
     [index: string]: ReadPropertyItem[];
 }
 
-export abstract class BeolResource {
+export abstract class BeolResource implements OnInit, OnDestroy {
 
     abstract iri: string;
     abstract resource: ReadResource;
@@ -47,7 +49,9 @@ export abstract class BeolResource {
 
     abstract propIris: PropIriToNameMapping;
 
-    constructor(protected _resourceService: ResourceService,
+    constructor(
+        protected _route: ActivatedRoute,
+        protected _resourceService: ResourceService,
         protected _cacheService: OntologyCacheService,
         protected _incomingService: IncomingService,
         protected _beolService: BeolService) {
@@ -143,6 +147,20 @@ export abstract class BeolResource {
             }
         }
         return invertedMapping;
+    }
+
+    ngOnInit() {
+        this.navigationSubscription = this._route.paramMap.subscribe((params: ParamMap) => {
+            this.getResource(params.get('id'));
+        });
+
+    }
+
+    ngOnDestroy() {
+        if (this.navigationSubscription) {
+            this.navigationSubscription.unsubscribe();
+        }
+
     }
 
     /**

--- a/src/app/resource/biblio-items/biblio-items.component.spec.ts
+++ b/src/app/resource/biblio-items/biblio-items.component.spec.ts
@@ -40,7 +40,11 @@ describe('BiblioItemsComponent', () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: { params: of({ id }) }
+          useValue: { paramMap: of({
+                  get: () => {
+                      return id;
+                  }
+              })}
         },
         { provide: 'config', useValue: KuiCoreConfig }
       ]

--- a/src/app/resource/biblio-items/biblio-items.component.ts
+++ b/src/app/resource/biblio-items/biblio-items.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import {
     IncomingService,
@@ -55,7 +55,7 @@ class BiblioItemsProps implements PropertyValues {
     templateUrl: './biblio-items.component.html',
     styleUrls: ['./biblio-items.component.scss']
 })
-export class BiblioItemsComponent extends BeolResource implements OnDestroy {
+export class BiblioItemsComponent extends BeolResource {
 
     iri: string;
     resource: ReadResource;
@@ -126,27 +126,15 @@ export class BiblioItemsComponent extends BeolResource implements OnDestroy {
 
     props: BiblioItemsProps;
 
-    constructor(private _route: ActivatedRoute,
-                private _router: Router,
+    constructor(protected _route: ActivatedRoute,
                 protected _resourceService: ResourceService,
                 protected _cacheService: OntologyCacheService,
                 protected _incomingService: IncomingService,
                 public location: Location,
                 protected _beolService: BeolService) {
 
-        super(_resourceService, _cacheService, _incomingService, _beolService);
+        super(_route, _resourceService, _cacheService, _incomingService, _beolService);
 
-        this._route.params.subscribe((params: Params) => {
-            this.iri = params['id'];
-        });
-
-        // subscribe to the router events to reload the content
-        this.navigationSubscription = this._router.events.subscribe((e: any) => {
-            // if it is a NavigationEnd event re-initalise the component
-            if (e instanceof NavigationEnd) {
-                this.getResource(this.iri);
-            }
-        });
     }
 
     initProps() {
@@ -156,12 +144,6 @@ export class BiblioItemsComponent extends BeolResource implements OnDestroy {
         this.mapper(props);
 
         this.props = props;
-    }
-
-    ngOnDestroy() {
-        if (this.navigationSubscription) {
-            this.navigationSubscription.unsubscribe();
-        }
     }
 
 }

--- a/src/app/resource/endnote/endnote.component.spec.ts
+++ b/src/app/resource/endnote/endnote.component.spec.ts
@@ -46,7 +46,11 @@ describe('EndnoteComponent', () => {
             providers: [
                 {
                     provide: ActivatedRoute,
-                    useValue: {params: of({id})}
+                    useValue: { paramMap: of({
+                            get: () => {
+                                return id;
+                            }
+                        })}
                 },
                 {provide: 'config', useValue: KuiCoreConfig},
                 {provide: Location, useValue: locationStub}

--- a/src/app/resource/endnote/endnote.component.ts
+++ b/src/app/resource/endnote/endnote.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component } from '@angular/core';
 import { Location } from '@angular/common';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import {
     IncomingService,
     KnoraConstants,
@@ -8,8 +8,8 @@ import {
     OntologyInformation,
     ReadPropertyItem,
     ReadResource,
-    ResourceService,
-    ReadTextValue
+    ReadTextValue,
+    ResourceService
 } from '@knora/core';
 import { BeolResource, PropertyValues, PropIriToNameMapping } from '../beol-resource';
 import { Subscription } from 'rxjs';
@@ -28,7 +28,7 @@ class EndnoteProps implements PropertyValues {
     templateUrl: './endnote.component.html',
     styleUrls: ['./endnote.component.scss']
 })
-export class EndnoteComponent extends BeolResource implements OnDestroy {
+export class EndnoteComponent extends BeolResource {
 
     iri: string;
     resource: ReadResource;
@@ -47,27 +47,14 @@ export class EndnoteComponent extends BeolResource implements OnDestroy {
 
     props: EndnoteProps;
 
-    constructor(private _router: Router,
-                private _route: ActivatedRoute,
+    constructor(protected _route: ActivatedRoute,
                 protected _resourceService: ResourceService,
                 protected _incomingService: IncomingService,
                 protected _cacheService: OntologyCacheService,
                 public location: Location,
                 protected _beolService: BeolService) {
 
-        super(_resourceService, _cacheService, _incomingService, _beolService);
-
-        this._route.params.subscribe((params: Params) => {
-            this.iri = params['id'];
-        });
-
-        // subscribe to the router events to reload the content
-        this.navigationSubscription = this._router.events.subscribe((e: any) => {
-            // if it is a NavigationEnd event re-initalise the component
-            if (e instanceof NavigationEnd) {
-                this.getResource(this.iri);
-            }
-        });
+        super(_route, _resourceService, _cacheService, _incomingService, _beolService);
 
     }
 
@@ -80,9 +67,4 @@ export class EndnoteComponent extends BeolResource implements OnDestroy {
         this.props = props;
     }
 
-    ngOnDestroy() {
-        if (this.navigationSubscription) {
-            this.navigationSubscription.unsubscribe();
-        }
-    }
 }

--- a/src/app/resource/figure/figure.component.spec.ts
+++ b/src/app/resource/figure/figure.component.spec.ts
@@ -28,7 +28,11 @@ describe('FigureComponent', () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: { params: of({ id }) }
+          useValue: { paramMap: of({
+                  get: () => {
+                      return id;
+                  }
+              })}
         },
         { provide: Location, useValue: locationStub }
       ]

--- a/src/app/resource/figure/figure.component.ts
+++ b/src/app/resource/figure/figure.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import {
     IncomingService,
@@ -26,7 +26,7 @@ class FigureProps implements PropertyValues {
     templateUrl: './figure.component.html',
     styleUrls: ['./figure.component.scss']
 })
-export class FigureComponent extends BeolResource implements OnDestroy {
+export class FigureComponent extends BeolResource {
 
     iri: string;
     resource: ReadResource;
@@ -44,27 +44,15 @@ export class FigureComponent extends BeolResource implements OnDestroy {
 
     props: FigureProps;
 
-    constructor(private _route: ActivatedRoute,
-                private _router: Router,
+    constructor(protected _route: ActivatedRoute,
                 protected _resourceService: ResourceService,
                 protected _cacheService: OntologyCacheService,
                 protected _incomingService: IncomingService,
                 public location: Location,
                 protected _beolService: BeolService) {
 
-        super(_resourceService, _cacheService, _incomingService, _beolService);
+        super(_route, _resourceService, _cacheService, _incomingService, _beolService);
 
-        this._route.params.subscribe((params: Params) => {
-            this.iri = params['id'];
-        });
-
-        // subscribe to the router events to reload the content
-        this.navigationSubscription = this._router.events.subscribe((e: any) => {
-            // if it is a NavigationEnd event re-initalise the component
-            if (e instanceof NavigationEnd) {
-                this.getResource(this.iri);
-            }
-        });
     }
 
     initProps() {
@@ -76,9 +64,4 @@ export class FigureComponent extends BeolResource implements OnDestroy {
         this.props = props;
     }
 
-    ngOnDestroy() {
-        if (this.navigationSubscription) {
-            this.navigationSubscription.unsubscribe();
-        }
-    }
 }

--- a/src/app/resource/letter/letter.component.spec.ts
+++ b/src/app/resource/letter/letter.component.spec.ts
@@ -41,7 +41,11 @@ describe('LetterComponent', () => {
                 OntologyCacheService,
                 {
                     provide: ActivatedRoute,
-                    useValue: {params: of({id})}
+                    useValue: { paramMap: of({
+                            get: () => {
+                                return id;
+                            }
+                        })}
                 },
                 {provide: 'config', useValue: KuiCoreConfig}
             ]

--- a/src/app/resource/letter/letter.component.ts
+++ b/src/app/resource/letter/letter.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import {
     IncomingService,
@@ -8,7 +8,8 @@ import {
     OntologyInformation,
     ReadDateValue,
     ReadLinkValue,
-    ReadListValue, ReadPropertyItem,
+    ReadListValue,
+    ReadPropertyItem,
     ReadResource,
     ReadTextValue,
     ResourceService
@@ -44,7 +45,7 @@ class LetterProps implements PropertyValues {
     templateUrl: './letter.component.html',
     styleUrls: ['./letter.component.scss']
 })
-export class LetterComponent extends BeolResource implements OnDestroy {
+export class LetterComponent extends BeolResource {
 
     iri: string;
     resource: ReadResource;
@@ -78,27 +79,15 @@ export class LetterComponent extends BeolResource implements OnDestroy {
 
     props: LetterProps;
 
-    constructor(private _route: ActivatedRoute,
-                private _router: Router,
+    constructor(protected _route: ActivatedRoute,
                 protected _resourceService: ResourceService,
                 protected _cacheService: OntologyCacheService,
                 protected _incomingService: IncomingService,
                 public location: Location,
                 protected _beolService: BeolService) {
 
-        super(_resourceService, _cacheService, _incomingService, _beolService);
+        super(_route, _resourceService, _cacheService, _incomingService, _beolService);
 
-        this._route.params.subscribe((params: Params) => {
-            this.iri = params['id'];
-        });
-
-        // subscribe to the router events to reload the content
-        this.navigationSubscription = this._router.events.subscribe((e: any) => {
-            // if it is a NavigationEnd event re-initalise the component
-            if (e instanceof NavigationEnd) {
-                this.getResource(this.iri);
-            }
-        });
     }
 
     initProps() {
@@ -109,12 +98,6 @@ export class LetterComponent extends BeolResource implements OnDestroy {
 
         this.props = props;
 
-    }
-
-    ngOnDestroy() {
-        if (this.navigationSubscription) {
-            this.navigationSubscription.unsubscribe();
-        }
     }
 
 }

--- a/src/app/resource/person/person.component.spec.ts
+++ b/src/app/resource/person/person.component.spec.ts
@@ -40,7 +40,11 @@ describe('PersonComponent', () => {
                 {provide: Location},
                 {
                     provide: ActivatedRoute,
-                    useValue: {params: of({id})}
+                    useValue: { paramMap: of({
+                            get: () => {
+                                return id;
+                            }
+                        })}
                 },
                 {provide: 'config', useValue: KuiCoreConfig}
             ]

--- a/src/app/resource/person/person.component.ts
+++ b/src/app/resource/person/person.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import {
     IncomingService,
@@ -37,7 +37,7 @@ class PersonProps implements PropertyValues {
     templateUrl: './person.component.html',
     styleUrls: ['./person.component.scss']
 })
-export class PersonComponent extends BeolResource implements OnDestroy {
+export class PersonComponent extends BeolResource {
 
     iri: string;
     resource: ReadResource;
@@ -67,27 +67,15 @@ export class PersonComponent extends BeolResource implements OnDestroy {
 
     props: PersonProps;
 
-    constructor(private _route: ActivatedRoute,
-                private _router: Router,
+    constructor(protected _route: ActivatedRoute,
                 protected _resourceService: ResourceService,
                 protected _cacheService: OntologyCacheService,
                 protected _incomingService: IncomingService,
                 public location: Location,
                 protected _beolService: BeolService) {
 
-        super(_resourceService, _cacheService, _incomingService, _beolService);
+        super(_route, _resourceService, _cacheService, _incomingService, _beolService);
 
-        this._route.params.subscribe((params: Params) => {
-            this.iri = params['id'];
-        });
-
-        // subscribe to the router events to reload the content
-        this.navigationSubscription = this._router.events.subscribe((e: any) => {
-            // if it is a NavigationEnd event re-initalise the component
-            if (e instanceof NavigationEnd) {
-                this.getResource(this.iri);
-            }
-        });
     }
 
     initProps() {
@@ -99,9 +87,4 @@ export class PersonComponent extends BeolResource implements OnDestroy {
         this.props = props;
     }
 
-    ngOnDestroy() {
-        if (this.navigationSubscription) {
-            this.navigationSubscription.unsubscribe();
-        }
-    }
 }

--- a/src/app/resource/resource.component.spec.ts
+++ b/src/app/resource/resource.component.spec.ts
@@ -37,7 +37,11 @@ describe('ResourceComponent', () => {
             providers: [
                 {
                     provide: ActivatedRoute,
-                    useValue: {params: of({id})}
+                    useValue: { paramMap: of({
+                            get: () => {
+                                return id;
+                            }
+                        })}
                 },
                 {provide: 'config', useValue: KuiCoreConfig}
             ]

--- a/src/app/resource/resource.component.ts
+++ b/src/app/resource/resource.component.ts
@@ -1,26 +1,7 @@
-import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Params, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import {
-    ApiServiceError,
-    ApiServiceResult,
-    ConvertJSONLD,
-    ImageRegion,
-    IncomingService,
-    KnoraConstants,
-    OntologyCacheService,
-    OntologyInformation,
-    ReadLinkValue,
-    ReadPropertyItem,
-    ReadResource,
-    ReadResourcesSequence,
-    ReadStillImageFileValue,
-    ResourceService,
-    SearchService,
-    StillImageRepresentation,
-    Utils
-} from '@knora/core';
-import { RequestStillImageRepresentations } from '@knora/viewer';
+import { IncomingService, KnoraConstants, OntologyCacheService, OntologyInformation, ReadResource, ResourceService } from '@knora/core';
 import { BeolResource } from './beol-resource';
 import { Subscription } from 'rxjs';
 import { BeolService } from '../services/beol.service';
@@ -30,7 +11,7 @@ import { BeolService } from '../services/beol.service';
     templateUrl: './resource.component.html',
     styleUrls: ['./resource.component.scss']
 })
-export class ResourceComponent extends BeolResource implements OnDestroy {
+export class ResourceComponent extends BeolResource {
 
     iri: string;
     resource: ReadResource;
@@ -43,36 +24,17 @@ export class ResourceComponent extends BeolResource implements OnDestroy {
 
     propIris;
 
-    constructor(private _route: ActivatedRoute,
-        private _router: Router,
+    constructor(protected _route: ActivatedRoute,
         protected _resourceService: ResourceService,
         protected _cacheService: OntologyCacheService,
         protected _incomingService: IncomingService,
         public location: Location,
         protected _beolService: BeolService) {
 
-        super(_resourceService, _cacheService, _incomingService, _beolService);
-
-        this._route.params.subscribe((params: Params) => {
-            this.iri = params['id'];
-        });
-
-        // subscribe to the router events
-        this.navigationSubscription = this._router.events.subscribe((e: any) => {
-            // if it is a NavigationEnd event re-initalise the component
-            if (e instanceof NavigationEnd) {
-                this.getResource(this.iri);
-            }
-        });
+        super(_route, _resourceService, _cacheService, _incomingService, _beolService);
     }
 
     initProps() {
-    }
-
-    ngOnDestroy() {
-        if (this.navigationSubscription) {
-            this.navigationSubscription.unsubscribe();
-        }
     }
 
     /**

--- a/src/app/search-results/search-results.component.spec.ts
+++ b/src/app/search-results/search-results.component.spec.ts
@@ -55,7 +55,15 @@ describe('SearchResultsComponent', () => {
             providers: [
                 {
                     provide: ActivatedRoute,
-                    useValue: { params: of({ mode, q }) }
+                    useValue: { paramMap: of({
+                            get: (param: string) => {
+                                if (param === 'q') {
+                                    return q;
+                                } else {
+                                    return mode;
+                                }
+                            }
+                        })}
                 },
                 { provide: 'config', useValue: KuiCoreConfig },
                 { provide: SearchParamsService, useValue: mockSearchParamService},

--- a/src/app/search-results/search-results.component.ts
+++ b/src/app/search-results/search-results.component.ts
@@ -26,7 +26,7 @@ const jsonld = require('jsonld');
     templateUrl: './search-results.component.html',
     styleUrls: ['./search-results.component.scss']
 })
-export class SearchResultsComponent implements OnInit {
+export class SearchResultsComponent implements OnInit, OnDestroy {
 
     isLoading = true;
 
@@ -51,6 +51,8 @@ export class SearchResultsComponent implements OnInit {
     searchQuery: string;
     searchMode: string;
 
+    navigationSubscription: Subscription;
+
     constructor(
         private _route: ActivatedRoute,
         private _searchService: SearchService,
@@ -64,8 +66,8 @@ export class SearchResultsComponent implements OnInit {
 
     ngOnInit() {
 
-        this._route.params.subscribe((params: Params) => {
-            this.searchMode = params['mode'];
+        this.navigationSubscription = this._route.paramMap.subscribe((params: Params) => {
+            this.searchMode = params.get('mode');
 
             // init offset to 0
             this.offset = 0;
@@ -73,7 +75,7 @@ export class SearchResultsComponent implements OnInit {
             this.resetStep();
 
             if (this.searchMode === 'fulltext') {
-                this.searchQuery = params['q'];
+                this.searchQuery = params.get('q');
             } else if (this.searchMode === 'extended') {
                 this.gravsearchGenerator = this._searchParamsService.getSearchParams();
                 this.generateGravsearchQuery();
@@ -83,6 +85,12 @@ export class SearchResultsComponent implements OnInit {
             this.getResult();
         });
 
+    }
+
+    ngOnDestroy() {
+        if (this.navigationSubscription !== undefined) {
+            this.navigationSubscription.unsubscribe();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR moves the handling of parameters to the abstract class `BeolResource` wherever possible.
`paramMap` is used instead of the deprecated `params`.

closes #77 